### PR TITLE
Move demo scripts to examples folder to avoid package name conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ set(PY_SOURCES
     ${PROJECT_SOURCE_DIR}/chatglm_cpp/__init__.py
     ${PROJECT_SOURCE_DIR}/convert.py
     ${PROJECT_SOURCE_DIR}/setup.py
-    ${PROJECT_SOURCE_DIR}/cli_chat.py
-    ${PROJECT_SOURCE_DIR}/web_demo.py
+    ${PROJECT_SOURCE_DIR}/examples/cli_chat.py
+    ${PROJECT_SOURCE_DIR}/examples/web_demo.py
     ${PROJECT_SOURCE_DIR}/test_convert.py
     ${PROJECT_SOURCE_DIR}/test_chatglm_cpp.py)
 add_custom_target(lint

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ pip install .
 
 Run the Python example to chat with the quantized model:
 ```sh
-python3 cli_chat.py -m chatglm-ggml.bin -i
+cd examples && python3 cli_chat.py -m ../chatglm-ggml.bin -i
 ```
 
 You may also launch a web demo to chat in your browser:
 ```sh
-python3 web_demo.py -m chatglm-ggml.bin
+cd examples && python3 web_demo.py -m ../chatglm-ggml.bin
 ```
 
-For ChatGLM2, change the model path to `chatglm2-ggml.bin` and everything works fine.
+For ChatGLM2, change the model path to `../chatglm2-ggml.bin` and everything works fine.
 
 ![web_demo](docs/web_demo.jpg)
 

--- a/examples/cli_chat.py
+++ b/examples/cli_chat.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import chatglm_cpp
 
-DEFAULT_MODEL_PATH = Path(__file__).resolve().parent.parent.parent / "chatglm-ggml.bin"
+DEFAULT_MODEL_PATH = Path(__file__).resolve().parent.parent / "chatglm-ggml.bin"
 
 BANNER = """
     ________          __  ________    __  ___                 

--- a/examples/web_demo.py
+++ b/examples/web_demo.py
@@ -1,13 +1,16 @@
 # Adapted from https://github.com/THUDM/ChatGLM-6B/blob/main/web_demo.py
 
 import argparse
+from pathlib import Path
 
 import chatglm_cpp
 import gradio as gr
 import mdtex2html
 
+DEFAULT_MODEL_PATH = Path(__file__).resolve().parent.parent / "chatglm-ggml.bin"
+
 parser = argparse.ArgumentParser()
-parser.add_argument("-m", "--model", default="chatglm-ggml.bin", type=str)
+parser.add_argument("-m", "--model", default=DEFAULT_MODEL_PATH, type=Path)
 parser.add_argument("-t", "--threads", default=0, type=int)
 args = parser.parse_args()
 


### PR DESCRIPTION
This PR fixed python import error in #14, which is caused by the name conflict between the local directory and the installed package. For now I moved the demo scripts to a separate folder to avoid this conflict.