### PR TITLE
Fix pedantic errors. Parse args without getopt.h

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,3 @@
 [submodule "third_party/ggml"]
 	path = third_party/ggml
 	url = https://github.com/ggerganov/ggml.git
-[submodule "third_party/getopt"]
-	path = third_party/getopt
-	url = https://github.com/jingyu/getopt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib CACHE STRING "")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib CACHE STRING "")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin CACHE STRING "")
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 
@@ -28,6 +28,14 @@ endif ()
 if (GGML_PERF)
     add_compile_definitions(GGML_PERF)
 endif ()
+
+set(CPP_SOURCES
+    ${PROJECT_SOURCE_DIR}/chatglm.h
+    ${PROJECT_SOURCE_DIR}/chatglm.cpp
+    ${PROJECT_SOURCE_DIR}/chatglm_test.cpp
+    ${PROJECT_SOURCE_DIR}/chatglm_pybind.cpp)
+
+set_source_files_properties(${CPP_SOURCES} PROPERTIES COMPILE_FLAGS "-pedantic-errors")
 
 add_library(chatglm STATIC chatglm.cpp)
 target_link_libraries(chatglm PRIVATE ggml sentencepiece-static)
@@ -67,11 +75,6 @@ if (CHATGLM_ENABLE_PYBIND)
 endif ()
 
 # lint
-set(CPP_SOURCES
-    ${PROJECT_SOURCE_DIR}/chatglm.h
-    ${PROJECT_SOURCE_DIR}/chatglm.cpp
-    ${PROJECT_SOURCE_DIR}/chatglm_test.cpp
-    ${PROJECT_SOURCE_DIR}/chatglm_pybind.cpp)
 set(PY_SOURCES
     ${PROJECT_SOURCE_DIR}/chatglm_cpp/__init__.py
     ${PROJECT_SOURCE_DIR}/convert.py
@@ -88,8 +91,4 @@ add_custom_target(lint
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
     add_definitions("/wd4267 /wd4244 /wd4305 /Zc:strictStrings /utf-8")
-    target_sources(main
-      PRIVATE third_party/getopt/getopt_long.c)
-    target_include_directories(main
-      PUBLIC third_party/getopt/)
-endif()
+endif ()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ChatGLM.cpp
 
 [![CMake](https://github.com/li-plus/chatglm.cpp/actions/workflows/cmake.yml/badge.svg)](https://github.com/li-plus/chatglm.cpp/actions/workflows/cmake.yml)
+[![Python package](https://github.com/li-plus/chatglm.cpp/actions/workflows/python-package.yml/badge.svg)](https://github.com/li-plus/chatglm.cpp/actions/workflows/python-package.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 C++ implementation of [ChatGLM-6B](https://github.com/THUDM/ChatGLM-6B) and [ChatGLM2-6B](https://github.com/THUDM/ChatGLM2-6B) for real-time chatting on your MacBook.

--- a/chatglm.h
+++ b/chatglm.h
@@ -56,7 +56,7 @@ class GGMLContext {
   public:
     GGMLContext() : gctx_(nullptr) {}
 
-    GGMLContext(ggml_init_params params) : gctx_(ggml_init(params)) {
+    GGMLContext(size_t mem_size, void *mem_buffer, bool no_alloc) : gctx_(ggml_init({mem_size, mem_buffer, no_alloc})) {
         CHATGLM_CHECK(gctx_) << "failed to init ggml context";
     }
     // copy constructor
@@ -257,6 +257,9 @@ class BaseModelForConditionalGeneration {
     struct TokenIdScore {
         int id;
         float score;
+
+        TokenIdScore() = default;
+        TokenIdScore(int id, float score) : id(id), score(score) {}
 
         bool operator<(const TokenIdScore &other) const { return score < other.score; }
         bool operator>(const TokenIdScore &other) const { return score > other.score; }

--- a/chatglm_test.cpp
+++ b/chatglm_test.cpp
@@ -37,7 +37,7 @@ class ChatGLMTest : public ::testing::Test {
         scratch_buf.resize(1024 * 1024);
 
         ctx.gctx = GGMLContext({1024 * 1024, nullptr, false});
-        ctx.scratch = {.offs = 0, .size = scratch_buf.size(), .data = scratch_buf.data()};
+        ctx.scratch = {0, scratch_buf.size(), scratch_buf.data()};
         ctx.gf = {};
         ctx.gf.n_threads = 1;
     }
@@ -785,7 +785,7 @@ TEST(Pipeline, ChatGLM) {
     if (!fs::exists(model_path)) {
         GTEST_SKIP() << "Skipping ChatGLM e2e test (ggml model not found)";
     }
-    Pipeline pipeline(model_path);
+    Pipeline pipeline(model_path.string());
     EXPECT_TRUE(dynamic_cast<ChatGLMForConditionalGeneration *>(pipeline.model.get()));
 
     // ===== tokenization =====
@@ -855,7 +855,7 @@ TEST(Pipeline, ChatGLM2) {
     if (!fs::exists(model_path)) {
         GTEST_SKIP() << "Skipping ChatGLM2 e2e test (ggml model not found)";
     }
-    Pipeline pipeline(model_path);
+    Pipeline pipeline(model_path.string());
     EXPECT_TRUE(dynamic_cast<ChatGLM2ForConditionalGeneration *>(pipeline.model.get()));
 
     // ===== tokenization =====
@@ -958,7 +958,7 @@ static void run_benchmark(const fs::path &model_path) {
 
     ggml_time_init();
     int64_t start_ms = ggml_time_ms();
-    Pipeline pipeline(model_path);
+    Pipeline pipeline(model_path.string());
     int64_t load_model_ms = ggml_time_ms() - start_ms;
 
     start_ms = ggml_time_ms();


### PR DESCRIPTION
This PR:
* Implemented `parse_args` without `getopt.h` and removed 3rd party dependency.
* Fixed pedantic errors to use c++17 with MSVC.
* Added windows build test in CI.