### PR TITLE
Add verbose information (config/system/performance)

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@ struct Args {
     float top_p = 0.7;
     float temp = 0.95;
     int num_threads = 0;
+    bool verbose = false;
 };
 
 void usage(const char *prog) {
@@ -34,7 +35,8 @@ void usage(const char *prog) {
               << "  --top_k N               top-k sampling (default: 0)\n"
               << "  --top_p N               top-p sampling (default: 0.7)\n"
               << "  --temp N                temperature (default: 0.95)\n"
-              << "  -t, --threads N         number of threads for inference\n";
+              << "  -t, --threads N         number of threads for inference\n"
+              << "  -v, --verbose           display verbose output including config/system/performance info\n";
 }
 
 static Args parse_args(int argc, char **argv) {
@@ -64,6 +66,8 @@ static Args parse_args(int argc, char **argv) {
             args.temp = std::stof(argv[++i]);
         } else if (arg == "-t" || arg == "--threads") {
             args.num_threads = std::stoi(argv[++i]);
+        } else if (arg == "-v" || arg == "--verbose") {
+            args.verbose = true;
         } else {
             std::cerr << "Unknown argument: " << arg << std::endl;
             usage(argv[0]);
@@ -107,10 +111,18 @@ static bool get_utf8_line(std::string &line) { return !!std::getline(std::cin, l
 #endif
 
 void chat(const Args &args) {
+    ggml_time_init();
+    int64_t start_load_us = ggml_time_us();
     chatglm::Pipeline pipeline(args.model_path);
+    int64_t end_load_us = ggml_time_us();
+
     std::string model_name = pipeline.model->type_name();
 
-    chatglm::TextStreamer streamer(pipeline.tokenizer.get());
+    auto text_streamer = std::make_shared<chatglm::TextStreamer>(std::cout, pipeline.tokenizer.get());
+    auto perf_streamer = std::make_shared<chatglm::PerfStreamer>();
+    auto streamer = std::make_shared<chatglm::StreamerGroup>(
+        std::vector<std::shared_ptr<chatglm::BaseStreamer>>{text_streamer, perf_streamer});
+
     chatglm::GenerationConfig gen_config(args.max_length, args.max_context_length, args.temp > 0, args.top_k,
                                          args.top_p, args.temp, args.num_threads);
 
@@ -125,7 +137,40 @@ void chat(const Args &args) {
                   << R"( / /___/ / / / /_/ / /_/ /_/ / /___/ /  / // /__/ /_/ / /_/ / )" << '\n'
                   << R"( \____/_/ /_/\__,_/\__/\____/_____/_/  /_(_)___/ .___/ .___/  )" << '\n'
                   << R"(                                              /_/   /_/       )" << '\n';
+    }
 
+    if (args.verbose) {
+        std::cout << "system info: | "
+                  << "AVX = " << ggml_cpu_has_avx() << " | "
+                  << "AVX2 = " << ggml_cpu_has_avx2() << " | "
+                  << "AVX512 = " << ggml_cpu_has_avx512() << " | "
+                  << "AVX512_VBMI = " << ggml_cpu_has_avx512_vbmi() << " | "
+                  << "AVX512_VNNI = " << ggml_cpu_has_avx512_vnni() << " | "
+                  << "FMA = " << ggml_cpu_has_fma() << " | "
+                  << "NEON = " << ggml_cpu_has_neon() << " | "
+                  << "ARM_FMA = " << ggml_cpu_has_arm_fma() << " | "
+                  << "F16C = " << ggml_cpu_has_f16c() << " | "
+                  << "FP16_VA = " << ggml_cpu_has_fp16_va() << " | "
+                  << "WASM_SIMD = " << ggml_cpu_has_wasm_simd() << " | "
+                  << "BLAS = " << ggml_cpu_has_blas() << " | "
+                  << "SSE3 = " << ggml_cpu_has_sse3() << " | "
+                  << "VSX = " << ggml_cpu_has_vsx() << " |\n";
+
+        std::cout << "inference config: | "
+                  << "max_length = " << args.max_length << " | "
+                  << "max_context_length = " << args.max_context_length << " | "
+                  << "top_k = " << args.top_k << " | "
+                  << "top_p = " << args.top_p << " | "
+                  << "temperature = " << args.temp << " | "
+                  << "num_threads = " << args.num_threads << " |\n";
+
+        std::cout << "loaded " << pipeline.model->type_name() << " model from " << args.model_path
+                  << " within: " << (end_load_us - start_load_us) / 1000.f << " ms\n";
+
+        std::cout << std::endl;
+    }
+
+    if (args.interactive) {
         std::vector<std::string> history;
         while (1) {
             std::cout << std::setw(model_name.size()) << std::left << "Prompt"
@@ -139,12 +184,19 @@ void chat(const Args &args) {
             }
             history.emplace_back(std::move(prompt));
             std::cout << model_name << " > ";
-            std::string output = pipeline.chat(history, gen_config, &streamer);
+            std::string output = pipeline.chat(history, gen_config, streamer.get());
             history.emplace_back(std::move(output));
+            if (args.verbose) {
+                std::cout << "\n" << perf_streamer->to_string() << "\n\n";
+            }
+            perf_streamer->reset();
         }
         std::cout << "Bye\n";
     } else {
-        pipeline.chat({args.prompt}, gen_config, &streamer);
+        pipeline.chat({args.prompt}, gen_config, streamer.get());
+        if (args.verbose) {
+            std::cout << "\n" << perf_streamer->to_string() << "\n\n";
+        }
     }
 }
 


### PR DESCRIPTION
Support displaying verbose output including config, system and performance information. Enable it by passing `-v` or `--verbose` to the `main` program. This should resolve #8.

Sample output:
```
$ ./build/bin/main -m chatglm2-ggml.bin -p 你好 -v -t 16
system info: | AVX = 1 | AVX2 = 1 | AVX512 = 0 | AVX512_VBMI = 0 | AVX512_VNNI = 0 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 |
inference config: | max_length = 2048 | max_context_length = 512 | top_k = 0 | top_p = 0.7 | temperature = 0.95 | num_threads = 16 |
loaded ChatGLM2 model from chatglm2-ggml.bin within: 25.119 ms

你好👋！我是人工智能助手 ChatGLM2-6B，很高兴见到你，欢迎问我任何问题。

prompt time: 633.128 ms / 17 tokens (37.242 ms/token)
output time: 2202.78 ms / 28 tokens (78.67 ms/token)
total time: 2835.91 ms
```