### PR TITLE
Support repetition penalty for generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CMake](https://github.com/li-plus/chatglm.cpp/actions/workflows/cmake.yml/badge.svg)](https://github.com/li-plus/chatglm.cpp/actions/workflows/cmake.yml)
 [![Python package](https://github.com/li-plus/chatglm.cpp/actions/workflows/python-package.yml/badge.svg)](https://github.com/li-plus/chatglm.cpp/actions/workflows/python-package.yml)
 [![PyPI](https://img.shields.io/pypi/v/chatglm-cpp)](https://pypi.org/project/chatglm-cpp/)
+![Python](https://img.shields.io/pypi/pyversions/chatglm-cpp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 C++ implementation of [ChatGLM-6B](https://github.com/THUDM/ChatGLM-6B) and [ChatGLM2-6B](https://github.com/THUDM/ChatGLM2-6B) for real-time chatting on your MacBook.
@@ -317,9 +318,31 @@ ChatGLM2-6B:
 
 ## Development
 
-* To perform unit tests, add the CMake flag `-DCHATGLM_ENABLE_TESTING=ON`, recompile, and run `./build/bin/chatglm_test`. For benchmark only, run `./build/bin/chatglm_test --gtest_filter=ChatGLM.benchmark`.
-* To format the code, run `cmake --build build --target lint`. You should have `clang-format`, `black` and `isort` pre-installed.
-* To check performance issue, add the CMake flag `-DGGML_PERF=ON`. It will show timing for each graph operation when running the model.
+**Unit Test & Benchmark**
+
+To perform unit tests, add this CMake flag `-DCHATGLM_ENABLE_TESTING=ON` to enable testing. Recompile and run the unit test (including benchmark).
+```sh
+mkdir -p build && cd build
+cmake .. -DCHATGLM_ENABLE_TESTING=ON && make -j
+./bin/chatglm_test
+```
+
+For benchmark only:
+```sh
+./bin/chatglm_test --gtest_filter='Benchmark.*'
+```
+
+**Lint**
+
+To format the code, run `make lint` inside the `build` folder. You should have `clang-format`, `black` and `isort` pre-installed.
+
+**Performance**
+
+To detect the performance bottleneck, add the CMake flag `-DGGML_PERF=ON`:
+```sh
+cmake .. -DGGML_PERF=ON && make -j
+```
+This will print timing for each graph operation when running the model.
 
 ## Acknowledgements
 

--- a/chatglm.h
+++ b/chatglm.h
@@ -281,12 +281,13 @@ struct GenerationConfig {
     int top_k;
     float top_p;
     float temperature;
+    float repetition_penalty;
     int num_threads;
 
     GenerationConfig(int max_length = 2048, int max_context_length = 512, bool do_sample = true, int top_k = 0,
-                     float top_p = 0.7, float temperature = 0.95, int num_threads = 0)
+                     float top_p = 0.7, float temperature = 0.95, float repetition_penalty = 1.f, int num_threads = 0)
         : max_length(max_length), max_context_length(max_context_length), do_sample(do_sample), top_k(top_k),
-          top_p(top_p), temperature(temperature), num_threads(num_threads) {}
+          top_p(top_p), temperature(temperature), repetition_penalty(repetition_penalty), num_threads(num_threads) {}
 };
 
 enum ModelType {
@@ -331,6 +332,10 @@ class BaseModelForConditionalGeneration {
     int generate_next_token(const std::vector<int> &input_ids, const GenerationConfig &gen_config, int n_past,
                             int n_ctx);
 
+    // logits processor
+    static void sampling_repetition_penalty(float *first, float *last, const std::vector<int> &input_ids,
+                                            float penalty);
+    // logits warper
     static void sampling_temperature(float *first, float *last, float temp);
     static void sampling_top_k(TokenIdScore *first, TokenIdScore *kth, TokenIdScore *last);
     static TokenIdScore *sampling_top_p(TokenIdScore *first, TokenIdScore *last, float top_p);

--- a/chatglm.h
+++ b/chatglm.h
@@ -374,19 +374,6 @@ class ChatGLMTokenizer : public BaseTokenizer {
     int pad_token_id;
 };
 
-class GLMMLP {
-  public:
-    GLMMLP() = default;
-    GLMMLP(ModelContext *ctx, int hidden_size)
-        : dense_h_to_4h(ctx, hidden_size, 4 * hidden_size), dense_4h_to_h(ctx, 4 * hidden_size, hidden_size) {}
-
-    ggml_tensor *forward(ModelContext *ctx, ggml_tensor *hidden_states) const;
-
-  public:
-    Linear dense_h_to_4h;
-    Linear dense_4h_to_h;
-};
-
 class GLMSelfAttention {
   public:
     // TODO: kv cache type
@@ -401,6 +388,19 @@ class GLMSelfAttention {
     int num_attention_heads;
     ggml_tensor *k_cache; // [n_head, maxlen, head_size]
     ggml_tensor *v_cache; // [n_head, head_size, maxlen]
+};
+
+class GLMMLP {
+  public:
+    GLMMLP() = default;
+    GLMMLP(ModelContext *ctx, int hidden_size)
+        : dense_h_to_4h(ctx, hidden_size, 4 * hidden_size), dense_4h_to_h(ctx, 4 * hidden_size, hidden_size) {}
+
+    ggml_tensor *forward(ModelContext *ctx, ggml_tensor *hidden_states) const;
+
+  public:
+    Linear dense_h_to_4h;
+    Linear dense_4h_to_h;
 };
 
 class GLMBlock {

--- a/chatglm_pybind.cpp
+++ b/chatglm_pybind.cpp
@@ -48,14 +48,16 @@ PYBIND11_MODULE(_C, m) {
         .def("build_prompt", &BaseTokenizer::build_prompt);
 
     py::class_<GenerationConfig>(m, "GenerationConfig")
-        .def(py::init<int, int, bool, int, float, float, int>(), "max_length"_a = 2048, "max_context_length"_a = 512,
-             "do_sample"_a = true, "top_k"_a = 0, "top_p"_a = 0.7, "temperature"_a = 0.95, "num_threads"_a = 0)
+        .def(py::init<int, int, bool, int, float, float, float, int>(), "max_length"_a = 2048,
+             "max_context_length"_a = 512, "do_sample"_a = true, "top_k"_a = 0, "top_p"_a = 0.7, "temperature"_a = 0.95,
+             "repetition_penalty"_a = 1.0, "num_threads"_a = 0)
         .def_readwrite("max_length", &GenerationConfig::max_length)
         .def_readwrite("max_context_length", &GenerationConfig::max_context_length)
         .def_readwrite("do_sample", &GenerationConfig::do_sample)
         .def_readwrite("top_k", &GenerationConfig::top_k)
         .def_readwrite("top_p", &GenerationConfig::top_p)
         .def_readwrite("temperature", &GenerationConfig::temperature)
+        .def_readwrite("repetition_penalty", &GenerationConfig::repetition_penalty)
         .def_readwrite("num_threads", &GenerationConfig::num_threads);
 
     py::class_<ChatGLMConfig, BaseConfig>(m, "ChatGLMConfig");

--- a/chatglm_test.cpp
+++ b/chatglm_test.cpp
@@ -109,6 +109,21 @@ static std::vector<int> extract_sorted_ids(std::vector<TokenIdScore> &token_scor
     return token_ids;
 }
 
+TEST(Sampling, RepetitionPenalty) {
+    constexpr float penalty = 1.2;
+    std::vector<float> logits{0.96, 1.2, -2, -0.8, 0, 2.4, -1};
+    std::vector<int> input_ids{0, 2, 5, 2};
+    // reference
+    std::vector<float> target{0.8, 1.2, -2.4, -0.8, 0, 2, -1};
+    // test
+    BaseModelForConditionalGeneration::sampling_repetition_penalty(logits.data(), logits.data() + logits.size(),
+                                                                   input_ids, penalty);
+    // compare
+    for (size_t i = 0; i < logits.size(); i++) {
+        EXPECT_FLOAT_EQ(logits[i], target[i]);
+    }
+}
+
 TEST(Sampling, Temperature) {
     constexpr float temp = 0.7;
     std::vector<float> logits(64);

--- a/examples/cli_chat.py
+++ b/examples/cli_chat.py
@@ -31,6 +31,7 @@ def main():
     parser.add_argument("--top_k", default=0, type=int, help="top-k sampling")
     parser.add_argument("--top_p", default=0.7, type=float, help="top-p sampling")
     parser.add_argument("--temp", default=0.95, type=float, help="temperature")
+    parser.add_argument("--repeat_penalty", default=1.0, type=float, help="penalize repeat sequence of tokens")
     parser.add_argument("-t", "--threads", default=0, type=int, help="number of threads for inference")
     args = parser.parse_args()
 
@@ -47,6 +48,7 @@ def main():
         top_k=args.top_k,
         top_p=args.top_p,
         temperature=args.temp,
+        repetition_penalty=args.repeat_penalty,
         stream=True,
     )
 

--- a/main.cpp
+++ b/main.cpp
@@ -29,6 +29,7 @@ struct Args {
     int top_k = 0;
     float top_p = 0.7;
     float temp = 0.95;
+    float repeat_penalty = 1.0;
     int num_threads = 0;
     bool verbose = false;
 };
@@ -48,6 +49,7 @@ static void usage(const char *prog) {
               << "  --top_k N               top-k sampling (default: 0)\n"
               << "  --top_p N               top-p sampling (default: 0.7)\n"
               << "  --temp N                temperature (default: 0.95)\n"
+              << "  --repeat_penalty N      penalize repeat sequence of tokens (default: 1.0, 1.0 = disabled)\n"
               << "  -t, --threads N         number of threads for inference\n"
               << "  -v, --verbose           display verbose output including config/system/performance info\n";
 }
@@ -79,6 +81,8 @@ static Args parse_args(int argc, char **argv) {
             args.top_p = std::stof(argv[++i]);
         } else if (arg == "--temp") {
             args.temp = std::stof(argv[++i]);
+        } else if (arg == "--repeat_penalty") {
+            args.repeat_penalty = std::stof(argv[++i]);
         } else if (arg == "-t" || arg == "--threads") {
             args.num_threads = std::stoi(argv[++i]);
         } else if (arg == "-v" || arg == "--verbose") {
@@ -139,7 +143,7 @@ static void chat(Args &args) {
         std::vector<std::shared_ptr<chatglm::BaseStreamer>>{text_streamer, perf_streamer});
 
     chatglm::GenerationConfig gen_config(args.max_length, args.max_context_length, args.temp > 0, args.top_k,
-                                         args.top_p, args.temp, args.num_threads);
+                                         args.top_p, args.temp, args.repeat_penalty, args.num_threads);
 
     if (args.verbose) {
         std::cout << "system info: | "


### PR DESCRIPTION
Support `repetition_penalty` option in generation config to penalize repeat sequence of tokens. Should resolve #83.