### PR TITLE
add 'usage' in json output

### DIFF
--- a/chatglm_cpp/openai_api.py
+++ b/chatglm_cpp/openai_api.py
@@ -66,7 +66,7 @@ class ChatCompletionResponse(BaseModel):
     object: Literal["chat.completion", "chat.completion.chunk"]
     created: int = Field(default_factory=lambda: int(time.time()))
     choices: Union[List[ChatCompletionResponseChoice], List[ChatCompletionResponseStreamChoice]]
-    usage: List[ChatUsage]
+    usage: ChatUsage
 
     model_config = {
         "json_schema_extra": {
@@ -170,7 +170,7 @@ async def create_chat_completion(body: ChatCompletionRequest) -> ChatCompletionR
     return ChatCompletionResponse(
         object="chat.completion",
         choices=[ChatCompletionResponseChoice(message=ChatMessage(role="assistant", content=output))],
-        usage=[ChatUsage(prompt_tokens=pt, completion_tokens=rt, total_tokens=pt+rt)],
+        usage=ChatUsage(prompt_tokens=pt, completion_tokens=rt, total_tokens=pt+rt),
     )
 
 


### PR DESCRIPTION
参考https://github.com/THUDM/ChatGLM2-6B/pull/479，添加了json输出usage字段，解决wechat-gptbot、langchain等调项目赖usage计算token导致无法正常接入。

added keywork 'usage' of json output.
**修改前：**
(chatglm3-demo) chunzhamini@chunzhamini chatglm % curl http://127.0.0.1:8081/v1/chat/completions -H 'Content-Type: application/json' \ 
    -d '{"messages": [{"role": "user", "content": "你好"}]}'
{"id":"chatcmpl","model":"default-model","object":"chat.completion","created":1698732463,"choices":[{"index":0,"message":{"role":"assistant","content":"你好👋！我是人工智能助手 ChatGLM3-6B，很高兴见到你，欢迎问我任何问题。"},"finish_reason":"stop"}]}%  
**修改后：**
(chatglm3-demo) chunzhamini@chunzhamini chatglm.cpp % curl http://127.0.0.1:8081/v1/chat/completions -H 'Content-Type: application/json' \
    -d '{"messages": [{"role": "user", "content": "你好"}]}'
{"id":"chatcmpl","model":"default-model","object":"chat.completion","created":1698736418,"choices":[{"index":0,"message":{"role":"assistant","content":"你好👋！我是人工智能助手 ChatGLM3-6B，很高兴见到你，欢迎问我任何问题。"},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":43,"total_tokens":45}}% 