### PR TITLE
Initialize system prompt

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -220,7 +220,7 @@ static void chat(Args &args) {
 
         std::vector<std::string> history;
         // read from file: sys_prompt_fpath
-        if (args.sys_prompt_fpath != "") {
+        if (!args.sys_prompt_fpath.empty()) {
             history = set_sys_prompt_to_history(args.sys_prompt_fpath);
         }
         while (1) {


### PR DESCRIPTION
## 使用方法
1. 新建文本输入system prompt. 直接输入prompt内容, 不用回车.
2. 在启动时加入 -s path/to/system/prompt

## 原理
从文件读取system prompt, 前缀system_token_id, 并放入history.  即文件第一行role会被分配为<|system|>, 其余行会按照<|user|><|assistant|>顺序交替分配.

## 已知问题
+ clear会将system prompt一并清除.
+ ```CHATGLM_CHECK((history.size()) % 2 == 0)``` 不能使用. 因为history在用 -s 选项时是奇数, 不用 -s 时是偶数

## 效果
>注意这里用了clear, 所以会回到GLM的身份.

<img width="488" alt="image" src="https://github.com/li-plus/chatglm.cpp/assets/114126477/6bd0a660-22bb-44f9-a806-7363c3b3f897">
