### PR TITLE
Faster repetition penalty sampling operation

### DIFF
--- a/chatglm_cpp/__init__.py
+++ b/chatglm_cpp/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterator, List, Optional, Union
 import chatglm_cpp._C as _C
 from chatglm_cpp._C import ChatMessage
 
-__version__ = "0.3.0"
+__version__ = "0.3.1.dev"
 
 
 @dataclass

--- a/chatglm_test.cpp
+++ b/chatglm_test.cpp
@@ -118,7 +118,7 @@ TEST(Sampling, RepetitionPenalty) {
 }
 
 TEST(DISABLED_Sampling, BenchmarkRepetitionPenalty) {
-    constexpr float penalty = 1.2;
+    const float penalty = 1.2;
     constexpr size_t vocab_size = 128000;
     constexpr int seq_len = 32000;
     std::vector<float> logits(vocab_size);
@@ -130,7 +130,7 @@ TEST(DISABLED_Sampling, BenchmarkRepetitionPenalty) {
         input_ids[i] = i;
     }
 
-    auto fn = [&logits, &input_ids] {
+    auto fn = [&logits, &input_ids, penalty] {
         BaseModelForCausalLM::sampling_repetition_penalty(logits.data(), logits.data() + logits.size(), input_ids,
                                                           penalty);
     };

--- a/chatglm_test.cpp
+++ b/chatglm_test.cpp
@@ -135,7 +135,8 @@ TEST(DISABLED_Sampling, BenchmarkRepetitionPenalty) {
                                                           penalty);
     };
     auto elapsed_ms = timeit(fn, 2, 100);
-    std::cout << "cost " << elapsed_ms << " ms\n";
+    std::cout << "[" << ::testing::UnitTest::GetInstance()->current_test_info()->name() << "] " << elapsed_ms
+              << " ms\n";
 }
 
 TEST(Sampling, Temperature) {

--- a/chatglm_test.cpp
+++ b/chatglm_test.cpp
@@ -36,6 +36,8 @@ static inline char *read_tensor_data(char *ptr, ggml_tensor *tensor) {
 
 static inline float random() { return rand() / (float)RAND_MAX; }
 
+static inline float random(float lo, float hi) { return lo + random() * (hi - lo); }
+
 static inline void random_fill(ggml_tensor *tensor) {
     std::vector<float> values(ggml_nelements(tensor));
     for (float &v : values) {
@@ -113,6 +115,27 @@ TEST(Sampling, RepetitionPenalty) {
     for (size_t i = 0; i < logits.size(); i++) {
         EXPECT_FLOAT_EQ(logits[i], target[i]);
     }
+}
+
+TEST(DISABLED_Sampling, BenchmarkRepetitionPenalty) {
+    constexpr float penalty = 1.2;
+    constexpr size_t vocab_size = 128000;
+    constexpr int seq_len = 32000;
+    std::vector<float> logits(vocab_size);
+    for (auto &x : logits) {
+        x = random(-1, 1);
+    }
+    std::vector<int> input_ids(seq_len);
+    for (size_t i = 0; i < input_ids.size(); i++) {
+        input_ids[i] = i;
+    }
+
+    auto fn = [&logits, &input_ids] {
+        BaseModelForCausalLM::sampling_repetition_penalty(logits.data(), logits.data() + logits.size(), input_ids,
+                                                          penalty);
+    };
+    auto elapsed_ms = timeit(fn, 2, 100);
+    std::cout << "cost " << elapsed_ms << " ms\n";
 }
 
 TEST(Sampling, Temperature) {


### PR DESCRIPTION
Get rid of `unordered_set` which is slow. Use plain vector to deduplicate instead.